### PR TITLE
Refine planning inputs and landing experience

### DIFF
--- a/web/src/components/Inputs.tsx
+++ b/web/src/components/Inputs.tsx
@@ -1,5 +1,19 @@
 import Accordion from "./Accordion"
 import CurrencyInput from "./CurrencyInput"
+import {
+  SpendingCategoryPlan,
+  FutureExpensePlan,
+  FutureIncomePlan,
+  SPENDING_CATEGORY_PRESETS,
+  FUTURE_EXPENSE_OPTIONS,
+  FUTURE_INCOME_OPTIONS,
+  suggestedInflationForSpending,
+  suggestedInflationForExpense,
+  suggestedInflationForIncome,
+  createId,
+  defaultSpendingCategories,
+  totalSpendingFromCategories,
+} from "../lib/planning"
 
 export type StrategyName = "fixed" | "variable_percentage" | "guardrails"
 export type MarketSelection = string
@@ -45,10 +59,12 @@ type Props = {
   inflationPct?: number
   onInflationPct?: (v: number) => void
   onApplyPreset?: (name: "lean" | "baseline" | "fat") => void
-  otherIncomes?: { amount: number; start_year: number }[]
-  onOtherIncomesChange?: (rows: { amount: number; start_year: number }[]) => void
-  expenses?: { amount: number; at_year_from_now: number }[]
-  onExpensesChange?: (rows: { amount: number; at_year_from_now: number }[]) => void
+  spendingCategories: SpendingCategoryPlan[]
+  onSpendingCategoriesChange: (rows: SpendingCategoryPlan[]) => void
+  futureExpenses: FutureExpensePlan[]
+  onFutureExpensesChange: (rows: FutureExpensePlan[]) => void
+  futureIncomes: FutureIncomePlan[]
+  onFutureIncomesChange: (rows: FutureIncomePlan[]) => void
   onRun: () => void
   running: boolean
 }
@@ -61,6 +77,20 @@ function FieldHeader({ label, help }: { label: string; help?: string }) {
     </div>
   )
 }
+
+function SectionHeader({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <div>
+      <h4 className="title" style={{ marginBottom: 4 }}>{title}</h4>
+      {hint && <p className="subtitle" style={{ marginBottom: 12 }}>{hint}</p>}
+    </div>
+  )
+}
+
+const frequencyOptions = [
+  { value: "one_time" as const, label: "One-time" },
+  { value: "recurring" as const, label: "Recurring" },
+]
 
 export default function Inputs({
   market,
@@ -98,19 +128,131 @@ export default function Inputs({
   inflationPct = 3,
   onInflationPct,
   onApplyPreset,
-  otherIncomes = [],
-  onOtherIncomesChange,
-  expenses = [],
-  onExpensesChange,
+  spendingCategories,
+  onSpendingCategoriesChange,
+  futureExpenses,
+  onFutureExpensesChange,
+  futureIncomes,
+  onFutureIncomesChange,
   onRun,
   running,
 }: Props) {
+  const totalBreakdown = totalSpendingFromCategories(spendingCategories)
+
+  const handleCategoryChange = (index: number, update: Partial<SpendingCategoryPlan>) => {
+    const next = spendingCategories.map((item, idx) => (idx === index ? { ...item, ...update } : item))
+    onSpendingCategoriesChange(next)
+  }
+
+  const handleCategorySelect = (index: number, category: SpendingCategoryPlan["category"]) => {
+    const preset = SPENDING_CATEGORY_PRESETS.find((option) => option.key === category)
+    handleCategoryChange(index, {
+      category,
+      label: preset?.label ?? spendingCategories[index]?.label ?? "Custom",
+      inflation: suggestedInflationForSpending(category),
+    })
+  }
+
+  const handleAddCategory = () => {
+    const fallback = SPENDING_CATEGORY_PRESETS.find((option) => option.key === "other")
+    const next = [
+      ...spendingCategories,
+      {
+        id: createId(),
+        label: fallback?.label ?? "Custom need",
+        amount: 0,
+        inflation: fallback?.inflation ?? 2.5,
+        category: (fallback?.key ?? "other") as SpendingCategoryPlan["category"],
+      },
+    ]
+    onSpendingCategoriesChange(next)
+  }
+
+  const handleRemoveCategory = (index: number) => {
+    const next = spendingCategories.filter((_, idx) => idx !== index)
+    if (!next.length) {
+      onSpendingCategoriesChange(defaultSpendingCategories(spend))
+      return
+    }
+    onSpendingCategoriesChange(next)
+  }
+
+  const handleExpenseChange = (index: number, update: Partial<FutureExpensePlan>) => {
+    const next = futureExpenses.map((item, idx) => (idx === index ? { ...item, ...update } : item))
+    onFutureExpensesChange(next)
+  }
+
+  const handleExpenseCategory = (index: number, category: FutureExpensePlan["category"]) => {
+    const option = FUTURE_EXPENSE_OPTIONS.find((item) => item.key === category)
+    handleExpenseChange(index, {
+      category,
+      label: option?.label ?? futureExpenses[index]?.label ?? "Goal",
+      inflation: suggestedInflationForExpense(category),
+    })
+  }
+
+  const handleAddExpense = () => {
+    const option = FUTURE_EXPENSE_OPTIONS[0]
+    onFutureExpensesChange([
+      ...futureExpenses,
+      {
+        id: createId(),
+        label: option.label,
+        amount: 0,
+        startYear: 1,
+        years: 1,
+        inflation: option.defaultInflation,
+        category: option.key,
+        frequency: "one_time",
+      },
+    ])
+  }
+
+  const handleRemoveExpense = (index: number) => {
+    onFutureExpensesChange(futureExpenses.filter((_, idx) => idx !== index))
+  }
+
+  const handleIncomeChange = (index: number, update: Partial<FutureIncomePlan>) => {
+    const next = futureIncomes.map((item, idx) => (idx === index ? { ...item, ...update } : item))
+    onFutureIncomesChange(next)
+  }
+
+  const handleIncomeCategory = (index: number, category: FutureIncomePlan["category"]) => {
+    const option = FUTURE_INCOME_OPTIONS.find((item) => item.key === category)
+    handleIncomeChange(index, {
+      category,
+      label: option?.label ?? futureIncomes[index]?.label ?? "Income",
+      inflation: suggestedInflationForIncome(category),
+    })
+  }
+
+  const handleAddIncome = () => {
+    const option = FUTURE_INCOME_OPTIONS[0]
+    onFutureIncomesChange([
+      ...futureIncomes,
+      {
+        id: createId(),
+        label: option.label,
+        amount: 0,
+        startYear: 1,
+        years: 30,
+        inflation: option.defaultInflation,
+        category: option.key,
+        frequency: "recurring",
+      },
+    ])
+  }
+
+  const handleRemoveIncome = (index: number) => {
+    onFutureIncomesChange(futureIncomes.filter((_, idx) => idx !== index))
+  }
+
   return (
     <div className="panel vstack plan-card">
       <div className="plan-card__heading">
         <div>
           <h3 className="title">Your Plan</h3>
-          <p className="subtitle">Tune assumptions, then stress-test against historical and Monte Carlo scenarios.</p>
+          <p className="subtitle">Outline your profile, goals, and assumptions. We'll translate everything into real-dollar cash flows.</p>
         </div>
         {onApplyPreset && (
           <div className="preset-row">
@@ -125,69 +267,270 @@ export default function Inputs({
       </div>
 
       <div className="plan-card__market">
-        <span className="label">Market focus</span>
+        <span className="label">Market data set</span>
         <div className="segmented segmented-lg">
           {markets.map((option) => (
-            <button
-              key={option.key}
-              type="button"
-              className={market === option.key ? "active" : ""}
-              onClick={() => onMarketChange(option.key)}
-            >
+            <button key={option.key} type="button" className={market === option.key ? "active" : ""} onClick={() => onMarketChange(option.key)}>
               {option.label}
             </button>
           ))}
         </div>
       </div>
 
-      <FieldHeader label="Initial portfolio" help="Starting portfolio in today's currency." />
-      <CurrencyInput value={initial} onChange={onInitial} currency={currencyCode} />
+      <div className="divider" />
 
-      <FieldHeader label="Annual spending" help="Amount you plan to spend per year in today's currency." />
-      <CurrencyInput value={spend} onChange={onSpend} currency={currencyCode} />
-
-      <div>
-        <FieldHeader label="Inflation" help="Expected annual inflation used for nominal projections." />
-        <input className="input" type="number" min={0} max={15} step={0.1} value={inflationPct} onChange={(e) => onInflationPct?.(Number(e.target.value))} />
-      </div>
-
+      <SectionHeader title="Household snapshot" hint="Capture your age, retirement horizon, and how long the plan should last." />
       <div className="row">
         <div>
-          <FieldHeader label="Working status" help="If you are still contributing, we'll project when you reach FI with the expected real return." />
+          <FieldHeader label="Current age" />
+          <input className="input" type="number" min={0} max={120} step={1} value={currentAge} onChange={(e) => onCurrentAge?.(Number(e.target.value))} />
+        </div>
+        <div>
+          <FieldHeader label="Working status" help="Helps determine whether we assume ongoing savings before retirement." />
           <select className="select" value={stillWorking ? "yes" : "no"} onChange={(e) => onStillWorking(e.target.value === "yes")}>
             <option value="yes">Still working</option>
             <option value="no">Already retired</option>
           </select>
         </div>
         <div>
-          <FieldHeader label="Years to fund" help="How long the plan needs to last." />
-          <input className="input" type="number" value={years} onChange={(e) => onYears(Number(e.target.value))} min={1} max={60} step={1} />
-        </div>
-        <div>
-          <FieldHeader label="Current age" />
-          <input className="input" type="number" min={0} max={120} step={1} value={currentAge} onChange={(e) => onCurrentAge?.(Number(e.target.value))} />
+          <FieldHeader label="Years to fund" help="How many retirement years you'd like to cover." />
+          <input className="input" type="number" min={1} max={60} step={1} value={years} onChange={(e) => onYears(Number(e.target.value))} />
         </div>
       </div>
 
-      {stillWorking && (
-        <div className="row">
-          <div>
-            <FieldHeader label="Annual savings" help="Amount added to the portfolio each year until retirement." />
-            <CurrencyInput value={annualContrib} onChange={onAnnualContrib} currency={currencyCode} />
-          </div>
-          <div>
-            <FieldHeader label="Expected real return (pre-retirement)" />
-            <input className="input" type="number" value={expectedRealReturn} onChange={(e) => onExpectedRealReturn(Number(e.target.value))} min={0} max={15} step={0.1} />
-          </div>
-          <div>
-            <FieldHeader label="Years until retirement" />
-            <input className="input" type="number" min={0} max={40} step={1} value={startDelayYears} onChange={(e) => onStartDelay(Number(e.target.value))} />
-          </div>
+      <div className="row">
+        <div>
+          <FieldHeader label="Years until retirement" help="Zero means you're retired now." />
+          <input className="input" type="number" min={0} max={40} step={1} value={startDelayYears} onChange={(e) => onStartDelay(Number(e.target.value))} />
         </div>
-      )}
+        <div>
+          <FieldHeader label="Annual savings until retirement" />
+          <CurrencyInput value={annualContrib} onChange={onAnnualContrib} currency={currencyCode} />
+        </div>
+        <div>
+          <FieldHeader label="Expected real return while working" help="Real (after inflation) annual growth assumption before retirement." />
+          <input className="input" type="number" min={0} max={15} step={0.1} value={expectedRealReturn} onChange={(e) => onExpectedRealReturn(Number(e.target.value))} />
+        </div>
+      </div>
 
+      <div className="divider" />
+
+      <SectionHeader title="Portfolio today" hint="What you've already saved and the inflation assumption for projections." />
+      <div className="row">
+        <div>
+          <FieldHeader label="Current invested portfolio" help="Starting balance in today's currency." />
+          <CurrencyInput value={initial} onChange={onInitial} currency={currencyCode} />
+        </div>
+        <div>
+          <FieldHeader label="Inflation assumption" help="Used when toggling to nominal (actual) dollars." />
+          <input className="input" type="number" min={0} max={15} step={0.1} value={inflationPct} onChange={(e) => onInflationPct?.(Number(e.target.value))} />
+        </div>
+      </div>
+
+      <div className="divider" />
+
+      <SectionHeader
+        title="Core spending plan"
+        hint="Break your lifestyle costs into categories. We keep everything in today’s dollars so you can compare apples to apples."
+      />
+      <FieldHeader label="Total annual living expenses" help="We'll scale the category amounts proportionally when you adjust this number." />
+      <CurrencyInput value={spend} onChange={onSpend} currency={currencyCode} />
+      <div className="help">Breakdown total: {currencyCode} {totalBreakdown.toLocaleString()}</div>
+
+      <div className="vstack" style={{ gap: 12 }}>
+        {spendingCategories.map((item, idx) => (
+          <div className="row" key={item.id}>
+            <div>
+              <FieldHeader label="Category" />
+              <select className="select" value={item.category} onChange={(e) => handleCategorySelect(idx, e.target.value as SpendingCategoryPlan["category"]) }>
+                {SPENDING_CATEGORY_PRESETS.map((option) => (
+                  <option key={option.key} value={option.key}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <FieldHeader label="Label" />
+              <input className="input" type="text" value={item.label} onChange={(e) => handleCategoryChange(idx, { label: e.target.value })} />
+            </div>
+            <div>
+              <FieldHeader label="Amount" />
+              <CurrencyInput value={item.amount} onChange={(value) => handleCategoryChange(idx, { amount: value })} currency={currencyCode} />
+            </div>
+            <div>
+              <FieldHeader label="Inflation %" help="We suggest a starting point based on the category." />
+              <input className="input" type="number" min={0} max={10} step={0.1} value={item.inflation} onChange={(e) => handleCategoryChange(idx, { inflation: Number(e.target.value) })} />
+            </div>
+            <div className="vstack" style={{ justifyContent: "flex-end" }}>
+              <button className="btn btn-secondary btn-sm" type="button" onClick={() => handleRemoveCategory(idx)}>
+                Remove
+              </button>
+            </div>
+          </div>
+        ))}
+        <div className="hstack" style={{ justifyContent: "space-between", marginTop: 4 }}>
+          <button className="btn btn-secondary btn-sm" type="button" onClick={handleAddCategory}>
+            Add category
+          </button>
+          <button className="btn btn-secondary btn-sm" type="button" onClick={() => onSpendingCategoriesChange(defaultSpendingCategories(spend))}>
+            Reset to suggested mix
+          </button>
+        </div>
+      </div>
+
+      <div className="divider" />
+
+      <SectionHeader
+        title="Future spending events"
+        hint="Model one-time goals (home purchase) or recurring costs (college, healthcare). Amounts are in today's dollars; we grow them by the category inflation."
+      />
+      <div className="vstack" style={{ gap: 12 }}>
+        {futureExpenses.map((item, idx) => (
+          <div className="row" key={item.id}>
+            <div>
+              <FieldHeader label="Type" />
+              <select className="select" value={item.category} onChange={(e) => handleExpenseCategory(idx, e.target.value as FutureExpensePlan["category"]) }>
+                {FUTURE_EXPENSE_OPTIONS.map((option) => (
+                  <option key={option.key} value={option.key}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <FieldHeader label="Label" />
+              <input className="input" type="text" value={item.label} onChange={(e) => handleExpenseChange(idx, { label: e.target.value })} />
+            </div>
+            <div>
+              <FieldHeader label="Amount" />
+              <CurrencyInput value={item.amount} onChange={(value) => handleExpenseChange(idx, { amount: value })} currency={currencyCode} />
+            </div>
+            <div>
+              <FieldHeader label="Starts in year" help="0 = this year, 1 = next year." />
+              <input className="input" type="number" min={0} max={60} step={1} value={item.startYear} onChange={(e) => handleExpenseChange(idx, { startYear: Number(e.target.value) })} />
+            </div>
+            <div>
+              <FieldHeader label="Frequency" />
+              <select
+                className="select"
+                value={item.frequency}
+                onChange={(e) => handleExpenseChange(idx, { frequency: e.target.value as FutureExpensePlan["frequency"], years: e.target.value === "recurring" ? item.years || 5 : 1 })}
+              >
+                {frequencyOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {item.frequency === "recurring" && (
+              <div>
+                <FieldHeader label="Years" />
+                <input className="input" type="number" min={1} max={40} step={1} value={item.years} onChange={(e) => handleExpenseChange(idx, { years: Number(e.target.value) })} />
+              </div>
+            )}
+            <div>
+              <FieldHeader label="Inflation %" />
+              <input className="input" type="number" min={0} max={10} step={0.1} value={item.inflation} onChange={(e) => handleExpenseChange(idx, { inflation: Number(e.target.value) })} />
+            </div>
+            <div className="vstack" style={{ justifyContent: "flex-end" }}>
+              <button className="btn btn-secondary btn-sm" type="button" onClick={() => handleRemoveExpense(idx)}>
+                Remove
+              </button>
+            </div>
+          </div>
+        ))}
+        <button className="btn btn-secondary btn-sm" type="button" onClick={handleAddExpense}>
+          Add goal or milestone
+        </button>
+      </div>
+
+      <div className="divider" />
+
+      <SectionHeader
+        title="Income streams"
+        hint="Document guaranteed income so the simulator knows when to offset withdrawals."
+      />
+      <div className="row">
+        <div>
+          <FieldHeader label="Recurring income" help="Pension or Social Security that repeats indefinitely." />
+          <CurrencyInput value={incomeAmount} onChange={onIncomeAmount} currency={currencyCode} />
+        </div>
+        <div>
+          <FieldHeader label="Starts in retirement year" help="Year offset from today (0 = immediately)." />
+          <input className="input" type="number" min={0} max={60} step={1} value={incomeStartYear} onChange={(e) => onIncomeStartYear(Number(e.target.value))} />
+        </div>
+      </div>
+
+      <Accordion title="Additional income sources">
+        <div className="vstack" style={{ gap: 12 }}>
+          {futureIncomes.map((item, idx) => (
+            <div className="row" key={item.id}>
+              <div>
+                <FieldHeader label="Type" />
+                <select className="select" value={item.category} onChange={(e) => handleIncomeCategory(idx, e.target.value as FutureIncomePlan["category"]) }>
+                  {FUTURE_INCOME_OPTIONS.map((option) => (
+                    <option key={option.key} value={option.key}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <FieldHeader label="Label" />
+                <input className="input" type="text" value={item.label} onChange={(e) => handleIncomeChange(idx, { label: e.target.value })} />
+              </div>
+              <div>
+                <FieldHeader label="Amount" />
+                <CurrencyInput value={item.amount} onChange={(value) => handleIncomeChange(idx, { amount: value })} currency={currencyCode} />
+              </div>
+              <div>
+                <FieldHeader label="Starts in year" />
+                <input className="input" type="number" min={0} max={60} step={1} value={item.startYear} onChange={(e) => handleIncomeChange(idx, { startYear: Number(e.target.value) })} />
+              </div>
+              <div>
+                <FieldHeader label="Frequency" />
+                <select
+                  className="select"
+                  value={item.frequency}
+                  onChange={(e) => handleIncomeChange(idx, { frequency: e.target.value as FutureIncomePlan["frequency"], years: e.target.value === "recurring" ? item.years || 30 : 1 })}
+                >
+                  {frequencyOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {item.frequency === "recurring" && (
+                <div>
+                  <FieldHeader label="Years" />
+                  <input className="input" type="number" min={1} max={60} step={1} value={item.years} onChange={(e) => handleIncomeChange(idx, { years: Number(e.target.value) })} />
+                </div>
+              )}
+              <div>
+                <FieldHeader label="Inflation %" />
+                <input className="input" type="number" min={0} max={10} step={0.1} value={item.inflation} onChange={(e) => handleIncomeChange(idx, { inflation: Number(e.target.value) })} />
+              </div>
+              <div className="vstack" style={{ justifyContent: "flex-end" }}>
+                <button className="btn btn-secondary btn-sm" type="button" onClick={() => handleRemoveIncome(idx)}>
+                  Remove
+                </button>
+              </div>
+            </div>
+          ))}
+          <button className="btn btn-secondary btn-sm" type="button" onClick={handleAddIncome}>
+            Add income stream
+          </button>
+        </div>
+      </Accordion>
+
+      <div className="divider" />
+
+      <SectionHeader title="Withdrawal model" hint="Choose how withdrawals adjust over time." />
       <div>
-        <span className="label">Withdrawal style</span>
+        <span className="label">Strategy</span>
         <div className="segmented">
           <button type="button" className={strategy === "fixed" ? "active" : ""} onClick={() => onStrategy("fixed")}>
             Fixed
@@ -203,7 +546,7 @@ export default function Inputs({
 
       {strategy === "variable_percentage" && (
         <div>
-          <FieldHeader label="Variable percentage" help="Annual percentage of portfolio withdrawn." />
+          <FieldHeader label="Variable percentage" help="Annual percentage of the portfolio withdrawn." />
           <input className="input" type="number" min={1} max={10} step={0.1} value={vpwPct} onChange={(e) => onVpwPct(Number(e.target.value))} />
         </div>
       )}
@@ -211,11 +554,11 @@ export default function Inputs({
       {strategy === "guardrails" && (
         <div className="row">
           <div>
-            <FieldHeader label="Guard band" help="Width of the acceptable withdrawal range based on the initial withdrawal rate." />
+            <FieldHeader label="Guard band %" help="Width of the acceptable withdrawal range based on the initial withdrawal rate." />
             <input className="input" type="number" min={5} max={50} step={1} value={guardBand} onChange={(e) => onGuardBand(Number(e.target.value))} />
           </div>
           <div>
-            <FieldHeader label="Adjust step" help="Percentage adjustment applied when breaching the guard band." />
+            <FieldHeader label="Adjust step %" help="Percentage change applied when hitting a guardrail." />
             <input className="input" type="number" min={5} max={30} step={1} value={guardStep} onChange={(e) => onGuardStep(Number(e.target.value))} />
           </div>
         </div>
@@ -223,126 +566,10 @@ export default function Inputs({
 
       <div className="divider" />
 
-      <Accordion title="Income in retirement">
-        <div className="row">
-          <div>
-            <FieldHeader label="Annual income" help="Recurring income that offsets withdrawals once retirement begins." />
-            <CurrencyInput value={incomeAmount} onChange={onIncomeAmount} currency={currencyCode} />
-          </div>
-          <div>
-            <FieldHeader label="Starts in retirement year" />
-            <input className="input" type="number" value={incomeStartYear} onChange={(e) => onIncomeStartYear(Number(e.target.value))} min={0} max={60} step={1} />
-          </div>
-        </div>
-        {onOtherIncomesChange && (
-          <div className="vstack">
-            <span className="label">Additional income streams</span>
-            {otherIncomes.map((row, idx) => (
-              <div className="row" key={`income-${idx}`}>
-                <CurrencyInput
-                  value={row.amount}
-                  onChange={(value) => {
-                    const next = otherIncomes.slice()
-                    next[idx] = { ...row, amount: value }
-                    onOtherIncomesChange(next)
-                  }}
-                  currency={currencyCode}
-                />
-                <input
-                  className="input"
-                  type="number"
-                  min={0}
-                  max={60}
-                  step={1}
-                  value={row.start_year}
-                  onChange={(e) => {
-                    const next = otherIncomes.slice()
-                    next[idx] = { ...row, start_year: Number(e.target.value) }
-                    onOtherIncomesChange(next)
-                  }}
-                />
-                <button
-                  className="btn"
-                  type="button"
-                  onClick={() => {
-                    const next = otherIncomes.filter((_, i) => i !== idx)
-                    onOtherIncomesChange(next)
-                  }}
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-            <button
-              className="btn btn-secondary btn-sm"
-              type="button"
-              onClick={() => onOtherIncomesChange([...(otherIncomes || []), { amount: 0, start_year: 0 }])}
-            >
-              Add income line
-            </button>
-          </div>
-        )}
-      </Accordion>
-
-      {onExpensesChange && (
-        <Accordion title="One-time expenses (years from now)">
-          <div className="vstack">
-            <div className="help">Model large purchases such as a home down payment. Amounts are expressed in today's currency.</div>
-            {expenses.map((row, idx) => (
-              <div className="row" key={`expense-${idx}`}>
-                <CurrencyInput
-                  value={row.amount}
-                  onChange={(value) => {
-                    const next = expenses.slice()
-                    next[idx] = { ...row, amount: value }
-                    onExpensesChange(next)
-                  }}
-                  currency={currencyCode}
-                />
-                <input
-                  className="input"
-                  type="number"
-                  min={0}
-                  max={60}
-                  step={1}
-                  value={row.at_year_from_now}
-                  onChange={(e) => {
-                    const next = expenses.slice()
-                    next[idx] = { ...row, at_year_from_now: Number(e.target.value) }
-                    onExpensesChange(next)
-                  }}
-                />
-                <button
-                  className="btn"
-                  type="button"
-                  onClick={() => {
-                    const next = expenses.filter((_, i) => i !== idx)
-                    onExpensesChange(next)
-                  }}
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-            <button
-              className="btn btn-secondary btn-sm"
-              type="button"
-              onClick={() => onExpensesChange([...(expenses || []), { amount: 0, at_year_from_now: 1 }])}
-            >
-              Add one-time expense
-            </button>
-          </div>
-        </Accordion>
-      )}
-
-      <div className="divider" />
-
       <button className="btn btn-primary btn-lg" onClick={onRun} disabled={running}>
         {running ? "Running..." : "Run simulation"}
       </button>
-
-      <div className="help">Runs every historical sequence and a Monte Carlo view for the selected market.</div>
+      <div className="help">We'll test your plan against every historical sequence and a block-bootstrap Monte Carlo simulation.</div>
     </div>
   )
 }
-

--- a/web/src/components/Landing.tsx
+++ b/web/src/components/Landing.tsx
@@ -1,11 +1,12 @@
 import Inputs, { StrategyName, MarketSelection } from "./Inputs"
+import { SpendingCategoryPlan, FutureExpensePlan, FutureIncomePlan } from "../lib/planning"
 
 interface MarketOption {
   key: MarketSelection
   label: string
 }
 
-export default function Landing(props: {
+type LandingProps = {
   market: MarketSelection
   markets: MarketOption[]
   onMarketChange: (market: MarketSelection) => void
@@ -43,74 +44,79 @@ export default function Landing(props: {
   onSimulate: () => void
   running: boolean
   onApplyPreset?: (name: "lean" | "baseline" | "fat") => void
-  otherIncomes?: { amount: number; start_year: number }[]
-  onOtherIncomesChange?: (rows: { amount: number; start_year: number }[]) => void
-  expenses?: { amount: number; at_year_from_now: number }[]
-  onExpensesChange?: (rows: { amount: number; at_year_from_now: number }[]) => void
-}) {
-  const p = props
+  spendingCategories: SpendingCategoryPlan[]
+  onSpendingCategoriesChange: (rows: SpendingCategoryPlan[]) => void
+  futureExpenses: FutureExpensePlan[]
+  onFutureExpensesChange: (rows: FutureExpensePlan[]) => void
+  futureIncomes: FutureIncomePlan[]
+  onFutureIncomesChange: (rows: FutureIncomePlan[]) => void
+}
+
+export default function Landing(p: LandingProps) {
   return (
     <div className="landing">
-      <div className="landing__grid">
-        <section className="landing__hero">
-          <span className="landing__tag">Now covering US and India markets</span>
-          <h1>Plan your FIRE journey with realistic market data</h1>
-          <p>
-            Stress-test your spending plan against every historical market path and a modern Monte Carlo simulation. Toggle markets, adjust assumptions, and get a feel for your odds before you pull the trigger.
-          </p>
-          <div className="landing__actions">
-            <button className="btn btn-primary btn-lg" type="button" onClick={p.onSimulate} disabled={p.running}>
-              {p.running ? "Preparing..." : "Jump to results"}
-            </button>
-            <span className="help">Or tailor the assumptions below first.</span>
-          </div>
-        </section>
-        <section className="landing__panel">
-          <Inputs
-            market={p.market}
-            markets={p.markets}
-            onMarketChange={p.onMarketChange}
-            currencyCode={p.currencyCode}
-            initial={p.initial}
-            onInitial={p.onInitial}
-            spend={p.spend}
-            onSpend={p.onSpend}
-            years={p.years}
-            onYears={p.onYears}
-            strategy={p.strategy}
-            onStrategy={p.onStrategy}
-            vpwPct={p.vpwPct}
-            onVpwPct={p.onVpwPct}
-            guardBand={p.guardBand}
-            onGuardBand={p.onGuardBand}
-            guardStep={p.guardStep}
-            onGuardStep={p.onGuardStep}
-            startDelayYears={p.startDelayYears}
-            onStartDelay={p.onStartDelay}
-            annualContrib={p.annualContrib}
-            onAnnualContrib={p.onAnnualContrib}
-            incomeAmount={p.incomeAmount}
-            onIncomeAmount={p.onIncomeAmount}
-            incomeStartYear={p.incomeStartYear}
-            onIncomeStartYear={p.onIncomeStartYear}
-            stillWorking={p.stillWorking}
-            onStillWorking={p.onStillWorking}
-            expectedRealReturn={p.expectedRealReturn}
-            onExpectedRealReturn={p.onExpectedRealReturn}
-            currentAge={p.currentAge}
-            onCurrentAge={p.onCurrentAge}
-            inflationPct={p.inflationPct}
-            onInflationPct={p.onInflationPct}
-            otherIncomes={p.otherIncomes}
-            onOtherIncomesChange={p.onOtherIncomesChange}
-            expenses={p.expenses}
-            onExpensesChange={p.onExpensesChange}
-            onRun={p.onSimulate}
-            running={p.running}
-            onApplyPreset={p.onApplyPreset}
-          />
-        </section>
-      </div>
+      <section className="landing__hero">
+        <span className="landing__tag">Now covering US and India markets</span>
+        <h1>Plan your FIRE journey with realistic market data</h1>
+        <p>
+          Stress-test your spending plan against every historical market path and a modern Monte Carlo simulation. Toggle markets,
+          adjust assumptions, and get a feel for your odds before you pull the trigger.
+        </p>
+        <div className="landing__actions">
+          <button className="btn btn-primary btn-lg" type="button" onClick={p.onSimulate} disabled={p.running}>
+            {p.running ? "Preparing..." : "Jump to results"}
+          </button>
+          <span className="help">Or tailor the assumptions below first.</span>
+        </div>
+      </section>
+
+      <section className="landing__panel">
+        <Inputs
+          market={p.market}
+          markets={p.markets}
+          onMarketChange={p.onMarketChange}
+          currencyCode={p.currencyCode}
+          initial={p.initial}
+          onInitial={p.onInitial}
+          spend={p.spend}
+          onSpend={p.onSpend}
+          years={p.years}
+          onYears={p.onYears}
+          strategy={p.strategy}
+          onStrategy={p.onStrategy}
+          vpwPct={p.vpwPct}
+          onVpwPct={p.onVpwPct}
+          guardBand={p.guardBand}
+          onGuardBand={p.onGuardBand}
+          guardStep={p.guardStep}
+          onGuardStep={p.onGuardStep}
+          startDelayYears={p.startDelayYears}
+          onStartDelay={p.onStartDelay}
+          annualContrib={p.annualContrib}
+          onAnnualContrib={p.onAnnualContrib}
+          incomeAmount={p.incomeAmount}
+          onIncomeAmount={p.onIncomeAmount}
+          incomeStartYear={p.incomeStartYear}
+          onIncomeStartYear={p.onIncomeStartYear}
+          stillWorking={p.stillWorking}
+          onStillWorking={p.onStillWorking}
+          expectedRealReturn={p.expectedRealReturn}
+          onExpectedRealReturn={p.onExpectedRealReturn}
+          currentAge={p.currentAge}
+          onCurrentAge={p.onCurrentAge}
+          inflationPct={p.inflationPct}
+          onInflationPct={p.onInflationPct}
+          spendingCategories={p.spendingCategories}
+          onSpendingCategoriesChange={p.onSpendingCategoriesChange}
+          futureExpenses={p.futureExpenses}
+          onFutureExpensesChange={p.onFutureExpensesChange}
+          futureIncomes={p.futureIncomes}
+          onFutureIncomesChange={p.onFutureIncomesChange}
+          onRun={p.onSimulate}
+          running={p.running}
+          onApplyPreset={p.onApplyPreset}
+        />
+      </section>
     </div>
   )
 }

--- a/web/src/lib/planning.ts
+++ b/web/src/lib/planning.ts
@@ -1,0 +1,195 @@
+export type SpendingCategoryKey =
+  | "housing"
+  | "food"
+  | "transportation"
+  | "healthcare"
+  | "education"
+  | "travel"
+  | "childcare"
+  | "other"
+
+export interface SpendingCategoryPlan {
+  id: string
+  label: string
+  amount: number
+  inflation: number
+  category: SpendingCategoryKey
+}
+
+export type ExpenseCategoryKey =
+  | "home_project"
+  | "vehicle"
+  | "education"
+  | "healthcare"
+  | "travel"
+  | "wedding"
+  | "other"
+
+export type IncomeCategoryKey =
+  | "social_security"
+  | "pension"
+  | "rental"
+  | "inheritance"
+  | "business"
+  | "other"
+
+export interface FutureExpensePlan {
+  id: string
+  label: string
+  amount: number
+  startYear: number
+  years: number
+  inflation: number
+  category: ExpenseCategoryKey
+  frequency: "one_time" | "recurring"
+}
+
+export interface FutureIncomePlan {
+  id: string
+  label: string
+  amount: number
+  startYear: number
+  years: number
+  inflation: number
+  category: IncomeCategoryKey
+  frequency: "one_time" | "recurring"
+}
+
+export const SPENDING_CATEGORY_PRESETS: Array<{
+  key: SpendingCategoryKey
+  label: string
+  weight: number
+  inflation: number
+}> = [
+  { key: "housing", label: "Housing & utilities", weight: 0.3, inflation: 2.5 },
+  { key: "food", label: "Groceries & dining", weight: 0.18, inflation: 2.5 },
+  { key: "transportation", label: "Transportation", weight: 0.1, inflation: 2.3 },
+  { key: "healthcare", label: "Healthcare", weight: 0.12, inflation: 4 },
+  { key: "education", label: "Education & personal growth", weight: 0.07, inflation: 5 },
+  { key: "travel", label: "Travel & experiences", weight: 0.1, inflation: 3 },
+  { key: "childcare", label: "Family & childcare", weight: 0.08, inflation: 3.5 },
+  { key: "other", label: "Everything else", weight: 0.05, inflation: 2.5 },
+]
+
+export const FUTURE_EXPENSE_OPTIONS: Array<{
+  key: ExpenseCategoryKey
+  label: string
+  defaultInflation: number
+}> = [
+  { key: "home_project", label: "Home renovation / down payment", defaultInflation: 2.8 },
+  { key: "vehicle", label: "Vehicle purchase", defaultInflation: 3 },
+  { key: "education", label: "Education", defaultInflation: 5 },
+  { key: "healthcare", label: "Healthcare milestone", defaultInflation: 4.5 },
+  { key: "travel", label: "Travel splurge", defaultInflation: 3 },
+  { key: "wedding", label: "Wedding / celebration", defaultInflation: 3.2 },
+  { key: "other", label: "Custom goal", defaultInflation: 2.5 },
+]
+
+export const FUTURE_INCOME_OPTIONS: Array<{
+  key: IncomeCategoryKey
+  label: string
+  defaultInflation: number
+}> = [
+  { key: "social_security", label: "Social Security / government pension", defaultInflation: 2.4 },
+  { key: "pension", label: "Employer pension", defaultInflation: 2 },
+  { key: "rental", label: "Rental income", defaultInflation: 2.5 },
+  { key: "inheritance", label: "Inheritance / lump sum", defaultInflation: 0 },
+  { key: "business", label: "Business income", defaultInflation: 2.5 },
+  { key: "other", label: "Other income", defaultInflation: 2.5 },
+]
+
+export function createId() {
+  return Math.random().toString(36).slice(2, 10)
+}
+
+function roundCurrency(value: number) {
+  return Math.round(value * 100) / 100
+}
+
+export function totalSpendingFromCategories(categories: SpendingCategoryPlan[]): number {
+  return categories.reduce((acc, item) => acc + (Number.isFinite(item.amount) ? item.amount : 0), 0)
+}
+
+export function defaultSpendingCategories(total: number): SpendingCategoryPlan[] {
+  const safeTotal = Number.isFinite(total) && total > 0 ? total : 0
+  const categories: SpendingCategoryPlan[] = []
+  let running = 0
+  SPENDING_CATEGORY_PRESETS.forEach((preset, index) => {
+    const base = safeTotal * preset.weight
+    const amount = index === SPENDING_CATEGORY_PRESETS.length - 1 ? safeTotal - running : base
+    const rounded = roundCurrency(amount)
+    running += rounded
+    categories.push({
+      id: createId(),
+      label: preset.label,
+      amount: rounded,
+      inflation: preset.inflation,
+      category: preset.key,
+    })
+  })
+  return categories
+}
+
+export function scaleSpendingCategories(categories: SpendingCategoryPlan[], total: number): SpendingCategoryPlan[] {
+  const safeTotal = Number.isFinite(total) && total > 0 ? total : 0
+  if (!categories.length) return defaultSpendingCategories(safeTotal)
+  const current = totalSpendingFromCategories(categories)
+  if (current <= 0) return defaultSpendingCategories(safeTotal)
+  const ratio = safeTotal / current
+  let running = 0
+  return categories.map((item, index) => {
+    const scaled = roundCurrency(item.amount * ratio)
+    if (index === categories.length - 1) {
+      const correction = roundCurrency(safeTotal - running)
+      return { ...item, amount: correction }
+    }
+    running += scaled
+    return { ...item, amount: scaled }
+  })
+}
+
+export function suggestedInflationForExpense(category: ExpenseCategoryKey): number {
+  return FUTURE_EXPENSE_OPTIONS.find((option) => option.key === category)?.defaultInflation ?? 2.5
+}
+
+export function suggestedInflationForIncome(category: IncomeCategoryKey): number {
+  return FUTURE_INCOME_OPTIONS.find((option) => option.key === category)?.defaultInflation ?? 2.5
+}
+
+export function suggestedInflationForSpending(category: SpendingCategoryKey): number {
+  return SPENDING_CATEGORY_PRESETS.find((preset) => preset.key === category)?.inflation ?? 2.5
+}
+
+export function toRealAmount(amount: number, inflationPct: number, yearsFromNow: number): number {
+  if (!Number.isFinite(amount)) return 0
+  const rate = 1 + (Number.isFinite(inflationPct) ? inflationPct : 0) / 100
+  if (rate <= 0) return amount
+  const exponent = Math.max(0, yearsFromNow)
+  return amount / Math.pow(rate, exponent)
+}
+
+export function expandFutureExpenses(items: FutureExpensePlan[]): { amount: number; at_year_from_now: number }[] {
+  const expanded: { amount: number; at_year_from_now: number }[] = []
+  items.forEach((item) => {
+    const cycles = item.frequency === "recurring" ? Math.max(1, Math.round(item.years)) : 1
+    for (let i = 0; i < cycles; i++) {
+      const year = Math.max(0, Math.round(item.startYear + i))
+      const realAmount = toRealAmount(item.amount, item.inflation, year)
+      expanded.push({ amount: roundCurrency(realAmount), at_year_from_now: year })
+    }
+  })
+  return expanded
+}
+
+export function expandFutureIncomes(items: FutureIncomePlan[]): { amount: number; start_year: number }[] {
+  const expanded: { amount: number; start_year: number }[] = []
+  items.forEach((item) => {
+    const cycles = item.frequency === "recurring" ? Math.max(1, Math.round(item.years)) : 1
+    for (let i = 0; i < cycles; i++) {
+      const year = Math.max(0, Math.round(item.startYear + i))
+      const realAmount = toRealAmount(item.amount, item.inflation, year)
+      expanded.push({ amount: roundCurrency(realAmount), start_year: year })
+    }
+  })
+  return expanded
+}

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -378,13 +378,9 @@
 
 .landing {
   padding: 48px 0 72px;
-}
-
-.landing__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 32px;
-  align-items: stretch;
 }
 
 .landing__hero {
@@ -393,6 +389,9 @@
   justify-content: center;
   gap: 16px;
   padding: 0 24px;
+  max-width: 760px;
+  margin: 0 auto;
+  text-align: left;
 }
 
 .landing__tag {
@@ -436,7 +435,7 @@
 
 .landing__panel .plan-card {
   position: static;
-  width: min(720px, 100%);
+  width: min(880px, 100%);
 }
 
 .chart-card .recharts-surface {


### PR DESCRIPTION
## Summary
- wire App state into the new planning objects for spending categories, future expenses, and future incomes, including URL share serialization
- introduce planning helpers for default categories, inflation suggestions, and real-dollar conversions
- redesign the inputs experience to capture customer profile, portfolio, spending goals, and income streams with category defaults
- refresh the landing page hero copy/layout and supporting styles to highlight the new flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb76180f10832580199619b3798bb0